### PR TITLE
Add pip install requirements

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -7,7 +7,7 @@
 
 # Update pywikibot
 echo "📦 Updating pywikibot"
-cd pywikibot && git pull && cd ..
+cd pywikibot && git pull && pip install -r requirements.txt && cd ..
 
 echo "🏡 Working dir: $(pwd)"
 


### PR DESCRIPTION
[This change](https://gerrit.wikimedia.org/r/plugins/gitiles/pywikibot/core/+/2bde0123854672ea1ec0482dbab4d9c00c3617f7%5E%21/requirements.txt) in pywikibot made the bot stop working between January 3 and today (when I added this change directly in Toolforge).